### PR TITLE
Update auto_author_assign workflow to not use an external job

### DIFF
--- a/.github/workflows/auto_author_assign.yml
+++ b/.github/workflows/auto_author_assign.yml
@@ -12,4 +12,14 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v1.6.0
+      - name: Assign pull request to creator
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const creator = context.payload.pull_request.user.login;
+            github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [creator]
+            });


### PR DESCRIPTION
We can implement easily this functionality without needing an external job. This is better for security purpose.

